### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.7.4-stretch
+
+ADD . /interactive-viewer
+WORKDIR /interactive-viewer
+RUN apt update \
+    && apt install -y \
+    openexr libopenexr-dev zlib1g-dev \
+    && apt clean
+RUN pip install --upgrade pip 
+RUN python3 -m pip install --user -r tools/requirements.txt

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ To install the latest version of all packages, run:
 * [Chart.js](https://www.chartjs.org/)
 * [Plotly.js](https://plot.ly/javascript/)
 
+## Docker
+
+An alternative method to run this tool is to build the docker image:
+
+```docker build . -t interactive-viewer```
+
+Then, run the image in interactive mode to allow running python commands:
+
+```docker run --rm -it interactive-viewer bash```
+
+In order to keep everything persistent though, you should mount the repository folder onto the container:
+
+```docker run --rm -it -v `pwd`:/interactive-viewer interactive-viewer bash```
+
 ## Managing scenes
 
 To add a new scene, simply run:


### PR DESCRIPTION
This can be used to deploy the tool in web servers effortlessly
(including clusters in university that are more restrictive when it
comes to installing external tools with dependencies). The docker image
can also be used with singularity.